### PR TITLE
Enable `peerDependencies` in `typings.json`

### DIFF
--- a/src/interfaces/main.ts
+++ b/src/interfaces/main.ts
@@ -37,6 +37,7 @@ export interface ConfigJson {
   // Dependencies.
   dependencies?: Dependencies
   devDependencies?: Dependencies
+  peerDependencies?: Dependencies
   ambientDependencies?: Dependencies
   ambientDevDependencies?: Dependencies
 }
@@ -73,6 +74,7 @@ export interface DependencyTree {
   raw: string
   dependencies: DependencyBranch
   devDependencies: DependencyBranch
+  peerDependencies: DependencyBranch
   ambientDependencies: DependencyBranch
   ambientDevDependencies: DependencyBranch
 }

--- a/src/lib/compile.spec.ts
+++ b/src/lib/compile.spec.ts
@@ -24,6 +24,7 @@ test('compile', t => {
         },
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -36,6 +37,7 @@ test('compile', t => {
         browserTypings: 'typed.browser.d.ts',
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -47,6 +49,7 @@ test('compile', t => {
         typings: 'typings/b.d.ts',
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -58,6 +61,7 @@ test('compile', t => {
         typings: 'browser.d.ts',
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -68,6 +72,7 @@ test('compile', t => {
         raw: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -174,6 +179,7 @@ test('compile', t => {
         raw: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -211,6 +217,7 @@ test('compile', t => {
         raw: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -239,6 +246,7 @@ test('compile', t => {
         raw: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -279,6 +287,7 @@ test('compile', t => {
         typings: join(FIXTURE_DIR, 'node.d.ts'),
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -290,6 +299,7 @@ test('compile', t => {
         typings: join(FIXTURE_DIR, 'fs.d.ts'),
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -319,6 +329,7 @@ test('compile', t => {
         typings,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -352,6 +363,7 @@ test('compile', t => {
       typings: 'http://example.com/typings/index.d.ts',
       dependencies: {},
       devDependencies: {},
+      peerDependencies: {},
       ambientDependencies: {},
       ambientDevDependencies: {}
     }
@@ -372,6 +384,7 @@ test('compile', t => {
       raw: undefined,
       dependencies: {},
       devDependencies: {},
+      peerDependencies: {},
       ambientDependencies: {},
       ambientDevDependencies: {}
     }
@@ -393,6 +406,7 @@ test('compile', t => {
       raw: undefined,
       dependencies: {},
       devDependencies: {},
+      peerDependencies: {},
       ambientDependencies: {},
       ambientDevDependencies: {}
     }
@@ -403,6 +417,7 @@ test('compile', t => {
       src: join(FIXTURE_DIR, 'node_modules/test/package.json'),
       dependencies: {},
       devDependencies: {},
+      peerDependencies: {},
       ambientDependencies: {},
       ambientDevDependencies: {}
     }
@@ -487,6 +502,7 @@ test('compile', t => {
       typings: 'http://example.com/index.d.ts',
       dependencies: {},
       devDependencies: {},
+      peerDependencies: {},
       ambientDependencies: {},
       ambientDevDependencies: {}
     }

--- a/src/lib/dependencies.spec.ts
+++ b/src/lib/dependencies.spec.ts
@@ -19,6 +19,7 @@ test('dependencies', t => {
         browserTypings: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -30,6 +31,7 @@ test('dependencies', t => {
         browserTypings: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {},
         name: 'bower-dep',
@@ -49,6 +51,7 @@ test('dependencies', t => {
         name: 'example',
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -63,6 +66,7 @@ test('dependencies', t => {
         browserTypings: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -78,6 +82,7 @@ test('dependencies', t => {
         name: 'npm-dep',
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         ambientDependencies: {},
         ambientDevDependencies: {}
       }
@@ -89,6 +94,7 @@ test('dependencies', t => {
         browserTypings: undefined,
         dependencies: {},
         devDependencies: {},
+        peerDependencies: {},
         main: undefined,
         name: 'dep',
         raw: 'bower:dep',

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -1,7 +1,9 @@
 import extend = require('xtend')
 import Promise = require('any-promise')
-import { removeDependency, transformConfig, DefinitionOptions } from './utils/fs'
+import promiseFinally from 'promise-finally'
+import { transformConfig, transformDtsFile, rimraf } from './utils/fs'
 import { findProject } from './utils/find'
+import { getDependencyLocation } from './utils/path'
 
 /**
  * Uninstall options.
@@ -9,59 +11,97 @@ import { findProject } from './utils/find'
 export interface UninstallDependencyOptions {
   save?: boolean
   saveDev?: boolean
+  savePeer?: boolean
   ambient?: boolean
+  name: string
   cwd: string
 }
 
 /**
  * Uninstall a dependency, given a name.
  */
-export function uninstallDependency (name: string, options: UninstallDependencyOptions) {
-  const { ambient } = options
-
+export function uninstallDependency (options: UninstallDependencyOptions) {
   // Remove the dependency from fs and config.
-  function uninstall (options: DefinitionOptions) {
-    return removeDependency(options).then(() => writeToConfig(name, options))
+  function uninstall (options: UninstallDependencyOptions) {
+    return removeDependency(options).then(() => writeToConfig(options))
   }
 
   return findProject(options.cwd)
     .then(
-      (cwd) => uninstall(extend(options, { cwd, name, ambient })),
-      () => uninstall(extend(options, { name, ambient }))
+      (cwd) => uninstall(extend(options, { cwd })),
+      () => uninstall(options)
     )
 }
 
 /**
  * Delete the dependency from the configuration file.
  */
-function writeToConfig (name: string, options: UninstallDependencyOptions) {
+function writeToConfig (options: UninstallDependencyOptions) {
   if (options.save || options.saveDev) {
     return transformConfig(options.cwd, config => {
       if (options.save) {
         if (options.ambient) {
-          if (config.ambientDependencies) {
+          if (config.ambientDependencies && config.ambientDependencies[name]) {
             delete config.ambientDependencies[name]
+          } else {
+            return Promise.reject(new TypeError(`Typings for "${name}" are not listed in ambient dependencies`))
           }
         } else {
-          if (config.dependencies) {
+          if (config.dependencies && config.dependencies[name]) {
             delete config.dependencies[name]
+          } else {
+            return Promise.reject(new TypeError(`Typings for "${name}" are not listed in dependencies`))
           }
         }
       }
 
       if (options.saveDev) {
         if (options.ambient) {
-          if (config.ambientDevDependencies) {
+          if (config.ambientDevDependencies && config.ambientDevDependencies[name]) {
             delete config.ambientDevDependencies[name]
+          } else {
+            return Promise.reject(new TypeError(`Typings for "${name}" are not listed in ambient dev dependencies`))
           }
         } else {
-          if (config.devDependencies) {
+          if (config.devDependencies && config.devDependencies[name]) {
             delete config.devDependencies[name]
+          } else {
+            return Promise.reject(new TypeError(`Typings for "${name}" are not listed in dev dependencies`))
           }
+        }
+      }
+
+      if (options.savePeer) {
+        if (config.peerDependencies && config.peerDependencies[name]) {
+          delete config.peerDependencies[name]
+        } else {
+          return Promise.reject(new TypeError(`Typings for "${name}" are not listed in peer dependencies`))
         }
       }
 
       return config
     })
   }
+}
+
+/**
+ * Remove a dependency from the filesystem.
+ */
+export function removeDependency (options: UninstallDependencyOptions) {
+  const location = getDependencyLocation(options)
+
+  // Remove the dependency from typings.
+  function remove (path: string, file: string, dtsFile: string) {
+    return promiseFinally(rimraf(path), () => {
+      return transformDtsFile(dtsFile, (typings) => {
+        return typings.filter(x => x !== file)
+      })
+    })
+  }
+
+  // Remove dependencies concurrently.
+  return Promise.all([
+    remove(location.mainPath, location.mainFile, location.mainDtsFile),
+    remove(location.browserPath, location.browserFile, location.browserDtsFile)
+  ]).then(() => undefined)
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,6 +1,12 @@
-import { resolve, dirname, basename, relative, extname } from 'path'
+import { resolve, dirname, basename, relative, extname, join } from 'path'
 import { resolve as resolveUrl, parse as parseUrl } from 'url'
+import { TYPINGS_DIR, DTS_MAIN_FILE, DTS_BROWSER_FILE } from './config'
 import isAbsolute = require('is-absolute')
+
+const mainTypingsDir = join(TYPINGS_DIR, 'main/definitions')
+const browserTypingsDir = join(TYPINGS_DIR, 'browser/definitions')
+const ambientMainTypingsDir = join(TYPINGS_DIR, 'main/ambient')
+const ambientBrowserTypingsDir = join(TYPINGS_DIR, 'browser/ambient')
 
 /**
  * Check if a path looks like a HTTP url.
@@ -124,4 +130,48 @@ export function normalizeToDefinition (path: string) {
   const ext = extname(path)
 
   return toDefinition(ext ? path.slice(0, -ext.length) : path)
+}
+
+/**
+ * Get definition installation paths.
+ */
+export function getTypingsLocation (options: { cwd: string }) {
+  const typingsDir = join(options.cwd, TYPINGS_DIR)
+  const mainDtsFile = join(typingsDir, DTS_MAIN_FILE)
+  const browserDtsFile = join(typingsDir, DTS_BROWSER_FILE)
+
+  return { typingsDir, mainDtsFile, browserDtsFile }
+}
+
+/**
+ * Options for interacting with dependencies.
+ */
+export interface DefinitionOptions {
+  cwd: string
+  name: string
+  ambient?: boolean
+}
+
+/**
+ * Return the dependency output locations based on definition options.
+ */
+export function getDependencyLocation (options: DefinitionOptions) {
+  const mainDir = options.ambient ? ambientMainTypingsDir : mainTypingsDir
+  const browserDir = options.ambient ? ambientBrowserTypingsDir : browserTypingsDir
+
+  const { typingsDir, mainDtsFile, browserDtsFile } = getTypingsLocation(options)
+
+  const mainPath = join(options.cwd, mainDir, options.name)
+  const browserPath = join(options.cwd, browserDir, options.name)
+  const mainFile = join(mainPath, 'index.d.ts')
+  const browserFile = join(browserPath, 'index.d.ts')
+
+  return {
+    mainFile,
+    browserFile,
+    mainPath,
+    browserPath,
+    mainDtsFile,
+    browserDtsFile
+  }
 }


### PR DESCRIPTION
These dependencies act like `devDependencies` (E.g. install locally, don’t install when used as a dependency) but can be semantically separated for later logging, etc. 

* Enabled additional flags for `init`
* Tidied up install and uninstall utils from `fs`

Closes https://github.com/typings/typings/issues/203