### PR TITLE
Improve HTTP query support, infer name from .d.ts

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -27,11 +27,15 @@ if (!which('tsc')) {
 
 if (exec('tsc', { silent: true }).code !== 0) {
   console.log('tsc completed build as expected')
-  echo('')
+  console.log('')
 }
 
 require('../')
   .install({ cwd: process.cwd() })
   .then(function () {
-    echo('Success!')
+    console.log('Success!')
+  })
+  .catch(function (err) {
+    console.log(err.toString())
+    console.log(err.stack)
   })

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,10 +1,9 @@
 import Promise = require('any-promise')
 import extend = require('xtend')
-import { join } from 'path'
+import { join, basename } from 'path'
 import { ConfigJson } from './interfaces'
 import { writeJson, isFile, readJson } from './utils/fs'
 import { CONFIG_FILE } from './utils/config'
-import { inferDefinitionName } from './utils/path'
 
 const TSD_JSON_FILE = 'tsd.json'
 const DEFINITELYTYPED_REPO = 'DefinitelyTyped/DefinitelyTyped'
@@ -71,7 +70,7 @@ function upgradeTsdJson (tsdJson: TsdJson, config?: ConfigJson): ConfigJson {
 
     Object.keys(tsdJson.installed).forEach(function (path) {
       const dependency = tsdJson.installed[path]
-      const name = inferDefinitionName(path)
+      const name = basename(path, '.d.ts')
       const location = `github:${repo}/${path}#${dependency.commit}`
 
       typingsJson.ambientDependencies[name] = location

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -67,7 +67,7 @@ test('install', t => {
     const DEPENDENCY = '@scope/test=file:custom_typings/definition.d.ts'
     const REGISTRY_DEPENDENCY = 'registry:dt/node@>=4.0'
     const PEER_DEPENDENCY = 'file:custom_typings/named/typings.json'
-    const AMBIENT_DEPENDENCY = 'ambient-test=file:custom_typings/ambient.d.ts'
+    const AMBIENT_DEPENDENCY = 'file:custom_typings/ambient.d.ts'
     const FIXTURE_DIR = join(__dirname, '__test__/install-dependency-fixture')
     const CONFIG = join(FIXTURE_DIR, CONFIG_FILE)
 
@@ -131,21 +131,9 @@ test('install', t => {
             node: 'registry:dt/node#4.0.0+20160226132328'
           },
           ambientDevDependencies: {
-            'ambient-test': 'file:custom_typings/ambient.d.ts'
+            ambient: 'file:custom_typings/ambient.d.ts'
           }
         })
-      })
-  })
-
-  t.test('reject install if name is missing', t => {
-    const DEPENDENCY = 'file:custom_typings/definition.d.ts'
-    const FIXTURE_DIR = join(__dirname, '__test__/install-dependency-fixture')
-
-    t.plan(1)
-
-    return installDependencyRaw(DEPENDENCY, { cwd: FIXTURE_DIR, emitter })
-      .catch(err => {
-        t.ok(/^Unable to install dependency/.test(err.message))
       })
   })
 

--- a/src/lib/compile.ts
+++ b/src/lib/compile.ts
@@ -6,7 +6,7 @@ import { join, relative, basename } from 'path'
 import { DependencyTree, Overrides, Emitter } from '../interfaces'
 import { readFileFrom } from '../utils/fs'
 import { EOL, normalizeEOL } from '../utils/path'
-import { resolveFrom, relativeTo, isHttp, isModuleName, normalizeSlashes, fromDefinition, normalizeToDefinition, toDefinition } from '../utils/path'
+import { resolveFrom, relativeTo, isHttp, isModuleName, normalizeSlashes, pathFromDefinition, normalizeToDefinition, toDefinition } from '../utils/path'
 import { REFERENCE_REGEXP } from '../utils/references'
 import { PROJECT_NAME, CONFIG_FILE, DEPENDENCY_SEPARATOR } from '../utils/config'
 import { resolveDependency } from '../utils/parse'
@@ -75,7 +75,7 @@ interface CompileOptions extends Options {
 /**
  * Resolve override paths.
  */
-function resolveFromWithModuleNameOverride (src: string, to: string | boolean): string {
+function resolveFromOverride (src: string, to: string | boolean): string {
   if (typeof to === 'string') {
     if (isModuleName(to)) {
       const [moduleName, modulePath] = getModuleNameParts(to)
@@ -130,8 +130,8 @@ function getStringifyOptions (
       overrides[mainDefinition] = browserDefinition
     } else {
       for (const key of Object.keys(browser)) {
-        const from = resolveFromWithModuleNameOverride(tree.src, key) as string
-        const to = resolveFromWithModuleNameOverride(tree.src, browser[key])
+        const from = resolveFromOverride(tree.src, key) as string
+        const to = resolveFromOverride(tree.src, browser[key])
 
         overrides[from] = to
       }
@@ -413,10 +413,10 @@ function importPath (path: string, name: string, options: StringifyOptions) {
       return name
     }
 
-    return `${prefix}${DEPENDENCY_SEPARATOR}${modulePath ? fromDefinition(resolved) : resolved}`
+    return `${prefix}${DEPENDENCY_SEPARATOR}${modulePath ? pathFromDefinition(resolved) : resolved}`
   }
 
-  const relativePath = relativeTo(tree.src, fromDefinition(resolved))
+  const relativePath = relativeTo(tree.src, pathFromDefinition(resolved))
 
   return normalizeSlashes(join(prefix, relativePath))
 }
@@ -545,8 +545,8 @@ function stringifyFile (path: string, rawContents: string, rawPath: string, opti
     return meta + declareText(parent ? moduleName : name, moduleText)
   }
 
-  const modulePath = importPath(path, fromDefinition(path), options)
-  const prettyPath = normalizeSlashes(join(name, relativeTo(tree.src, fromDefinition(path))))
+  const modulePath = importPath(path, pathFromDefinition(path), options)
+  const prettyPath = normalizeSlashes(join(name, relativeTo(tree.src, pathFromDefinition(path))))
   const declared = declareText(modulePath, moduleText)
 
   if (!isEntry) {

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -19,7 +19,7 @@ import { join, dirname } from 'path'
 import { parse as parseUrl } from 'url'
 import template = require('string-template')
 import { CONFIG_FILE, TYPINGS_DIR, DTS_MAIN_FILE, DTS_BROWSER_FILE, PRETTY_PROJECT_NAME, HOMEPAGE } from './config'
-import { isHttp, toDefinition, EOL, detectEOL, normalizeEOL } from './path'
+import { isHttp, EOL, detectEOL, normalizeEOL } from './path'
 import { parseReferences, stringifyReferences } from './references'
 import { ConfigJson } from '../interfaces'
 import { CompiledOutput } from '../lib/compile'

--- a/src/utils/parse.spec.ts
+++ b/src/utils/parse.spec.ts
@@ -2,15 +2,19 @@ import test = require('blue-tape')
 import { normalize } from 'path'
 import { parseDependency, resolveDependency, expandRegistry } from './parse'
 import { CONFIG_FILE } from './config'
+import { Dependency } from '../interfaces'
 
 test('parse', t => {
   t.test('parse dependency', t => {
     t.test('parse filename', t => {
       const actual = parseDependency('file:./foo/bar.d.ts')
-      const expected = {
+      const expected: Dependency = {
         raw: 'file:./foo/bar.d.ts',
         location: normalize('foo/bar.d.ts'),
-        meta: { path: normalize('foo/bar.d.ts') },
+        meta: {
+          name: 'bar',
+          path: normalize('foo/bar.d.ts')
+        },
         type: 'file'
       }
 
@@ -20,10 +24,13 @@ test('parse', t => {
 
     t.test('parse filename relative', t => {
       const actual = parseDependency('file:foo/bar.d.ts')
-      const expected = {
+      const expected: Dependency = {
         raw: 'file:foo/bar.d.ts',
         location: normalize('foo/bar.d.ts'),
-        meta: { path: normalize('foo/bar.d.ts') },
+        meta: {
+          name: 'bar',
+          path: normalize('foo/bar.d.ts')
+        },
         type: 'file'
       }
 
@@ -33,7 +40,7 @@ test('parse', t => {
 
     t.test('parse npm', t => {
       const actual = parseDependency('npm:foobar')
-      const expected = {
+      const expected: Dependency = {
         raw: 'npm:foobar',
         type: 'npm',
         meta: {
@@ -49,7 +56,7 @@ test('parse', t => {
 
     t.test('parse scoped npm packages', t => {
       const actual = parseDependency('npm:@foo/bar')
-      const expected = {
+      const expected: Dependency = {
         raw: 'npm:@foo/bar',
         type: 'npm',
         meta: {
@@ -65,7 +72,7 @@ test('parse', t => {
 
     t.test('parse npm filename', t => {
       const actual = parseDependency('npm:typescript/bin/lib.es6.d.ts')
-      const expected = {
+      const expected: Dependency = {
         raw: 'npm:typescript/bin/lib.es6.d.ts',
         type: 'npm',
         meta: {
@@ -81,7 +88,7 @@ test('parse', t => {
 
     t.test('parse bower', t => {
       const actual = parseDependency('bower:foobar')
-      const expected = {
+      const expected: Dependency = {
         raw: 'bower:foobar',
         type: 'bower',
         meta: {
@@ -97,7 +104,7 @@ test('parse', t => {
 
     t.test('parse bower filename', t => {
       const actual = parseDependency('bower:foobar/' + CONFIG_FILE)
-      const expected = {
+      const expected: Dependency = {
         raw: 'bower:foobar/' + CONFIG_FILE,
         type: 'bower',
         meta: {
@@ -113,10 +120,11 @@ test('parse', t => {
 
     t.test('parse github', t => {
       const actual = parseDependency('github:foo/bar')
-      const expected = {
+      const expected: Dependency = {
         raw: 'github:foo/bar',
         type: 'github',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'typings.json',
           repo: 'bar',
@@ -131,10 +139,11 @@ test('parse', t => {
 
     t.test('parse github with sha and append config file', t => {
       const actual = parseDependency('github:foo/bar#test')
-      const expected = {
+      const expected: Dependency = {
         raw: 'github:foo/bar#test',
         type: 'github',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'typings.json',
           repo: 'bar',
@@ -149,10 +158,11 @@ test('parse', t => {
 
     t.test('parse github paths to `.d.ts` files', t => {
       const actual = parseDependency('github:foo/bar/typings/file.d.ts')
-      const expected = {
+      const expected: Dependency = {
         raw: 'github:foo/bar/typings/file.d.ts',
         type: 'github',
         meta: {
+          name: 'file',
           org: 'foo',
           path: 'typings/file.d.ts',
           repo: 'bar',
@@ -167,10 +177,11 @@ test('parse', t => {
 
     t.test('parse github paths to config file', t => {
       const actual = parseDependency('github:foo/bar/src/' + CONFIG_FILE)
-      const expected = {
+      const expected: Dependency = {
         raw: 'github:foo/bar/src/' + CONFIG_FILE,
         type: 'github',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'src/typings.json',
           repo: 'bar',
@@ -185,10 +196,11 @@ test('parse', t => {
 
     t.test('parse bitbucket', t => {
       const actual = parseDependency('bitbucket:foo/bar')
-      const expected = {
+      const expected: Dependency = {
         raw: 'bitbucket:foo/bar',
         type: 'bitbucket',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'typings.json',
           repo: 'bar',
@@ -203,10 +215,11 @@ test('parse', t => {
 
     t.test('parse bitbucket and append config file to path', t => {
       const actual = parseDependency('bitbucket:foo/bar/dir')
-      const expected = {
+      const expected: Dependency = {
         raw: 'bitbucket:foo/bar/dir',
         type: 'bitbucket',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'dir/typings.json',
           repo: 'bar',
@@ -221,10 +234,11 @@ test('parse', t => {
 
     t.test('parse bitbucket with sha', t => {
       const actual = parseDependency('bitbucket:foo/bar#abc')
-      const expected = {
+      const expected: Dependency = {
         raw: 'bitbucket:foo/bar#abc',
         type: 'bitbucket',
         meta: {
+          name: undefined,
           org: 'foo',
           path: 'typings.json',
           repo: 'bar',
@@ -239,7 +253,7 @@ test('parse', t => {
 
     t.test('parse url', t => {
       const actual = parseDependency('http://example.com/foo/' + CONFIG_FILE)
-      const expected = {
+      const expected: Dependency = {
         raw: 'http://example.com/foo/' + CONFIG_FILE,
         type: 'http',
         meta: {},
@@ -252,7 +266,7 @@ test('parse', t => {
 
     t.test('parse registry', t => {
       const actual = parseDependency('registry:dt/node')
-      const expected = {
+      const expected: Dependency = {
         raw: 'registry:dt/node',
         type: 'registry',
         meta: { name: 'node', source: 'dt', tag: undefined as string, version: undefined as string },
@@ -265,7 +279,7 @@ test('parse', t => {
 
     t.test('parse registry with scoped package', t => {
       const actual = parseDependency('registry:npm/@scoped/npm')
-      const expected = {
+      const expected: Dependency = {
         raw: 'registry:npm/@scoped/npm',
         type: 'registry',
         meta: { name: '@scoped/npm', source: 'npm', tag: undefined as string, version: undefined as string },
@@ -278,7 +292,7 @@ test('parse', t => {
 
     t.test('parse registry with tag', t => {
       const actual = parseDependency('registry:npm/dep#3.0.0-2016')
-      const expected = {
+      const expected: Dependency = {
         raw: 'registry:npm/dep#3.0.0-2016',
         type: 'registry',
         meta: { name: 'dep', source: 'npm', tag: '3.0.0-2016', version: undefined as string },
@@ -291,7 +305,7 @@ test('parse', t => {
 
     t.test('parse registry with version', t => {
       const actual = parseDependency('registry:npm/dep@^4.0')
-      const expected = {
+      const expected: Dependency = {
         raw: 'registry:npm/dep@^4.0',
         type: 'registry',
         meta: { name: 'dep', source: 'npm', tag: undefined as string, version: '^4.0' },

--- a/src/utils/path.spec.ts
+++ b/src/utils/path.spec.ts
@@ -1,0 +1,16 @@
+import test = require('blue-tape')
+import { pathFromDefinition } from './path'
+
+test('parse', t => {
+  t.test('path from definition', t => {
+    t.test('path', t => {
+      t.equal(pathFromDefinition('foo/bar.d.ts'), 'foo/bar')
+      t.end()
+    })
+
+    t.test('url', t => {
+      t.equal(pathFromDefinition('http://example.com/test.d.ts'), '/test')
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Closes https://github.com/typings/typings/issues/207 with improve query string resolution over imports.

Closes https://github.com/typings/typings/issues/329 by inferring the name from `basename` when installing directly from `.d.ts` file.