### PR TITLE
Set ambient to be optional. Default to false (undefined)

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -12,7 +12,7 @@ import { Emitter } from './interfaces'
 export interface BundleOptions {
   name?: string
   cwd: string
-  ambient: boolean
+  ambient?: boolean
   out: string
   emitter?: Emitter
 }


### PR DESCRIPTION
Similar argument to `out`, `ambient` can be optional and default to false.

Still would be best to record that in `typings.json`

UPDATE: So my proposal is either:
1. Allow `ambient` to be optional and default as false (undefined). i.e. this PR, or
2. Add a flag in `typings.json` such as `bundleAsAmbient` and pass it in.