### PR TITLE
Fix github authentication via personal access token

### DIFF
--- a/src/utils/parse.spec.ts
+++ b/src/utils/parse.spec.ts
@@ -3,6 +3,7 @@ import { normalize } from 'path'
 import { parseDependency, resolveDependency, expandRegistry } from './parse'
 import { CONFIG_FILE } from './config'
 import { Dependency } from '../interfaces'
+import rc from './rc';
 
 test('parse', t => {
   t.test('parse dependency', t => {
@@ -113,6 +114,31 @@ test('parse', t => {
         },
         location: normalize('foobar/' + CONFIG_FILE)
       }
+
+      t.deepEqual(actual, expected)
+      t.end()
+    })
+
+    t.test('parse github with github user and token', t => {
+      rc.githubUsername = 'foo';
+      rc.githubToken = 'bar';
+
+      const actual = parseDependency('github:foo/bar/typings.json')
+      const expected: Dependency = {
+        raw: 'github:foo/bar/typings.json',
+        type: 'github',
+        meta: {
+          name: undefined,
+          org: 'foo',
+          path: 'typings.json',
+          repo: 'bar',
+          sha: 'master'
+        },
+        location: 'https://foo:bar@raw.githubusercontent.com/foo/bar/master/typings.json'
+      }
+
+      rc.githubUsername = undefined;
+      rc.githubToken = undefined;
 
       t.deepEqual(actual, expected)
       t.end()

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -75,10 +75,16 @@ export function parseDependency (raw: string): Dependency {
   if (type === 'github') {
     const meta = gitFromPath(src)
     const { org, repo, path, sha, name } = meta
-    let location = `https://raw.githubusercontent.com/${org}/${repo}/${sha}/${path}`
+    let basicAuth = '';
 
-    if (rc.githubToken) {
-      location += `?token=${encodeURIComponent(rc.githubToken)}`
+    if (rc.githubToken && rc.githubUsername) {
+      basicAuth = `${encodeURIComponent(rc.githubUsername)}:${encodeURIComponent(rc.githubToken)}@`
+    }
+
+    let location = `https://${basicAuth}raw.githubusercontent.com/${org}/${repo}/${sha}/${path}`
+
+    if (rc.githubToken && !rc.githubUsername) {
+      location += `?token=${encodeURIComponent(rc.githubToken)}`;
     }
 
     return {

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -76,16 +76,17 @@ export function parseDependency (raw: string): Dependency {
     const meta = gitFromPath(src)
     const { org, repo, path, sha, name } = meta
     let basicAuth = '';
+    let tokenQueryString = '';
 
-    if (rc.githubToken && rc.githubUsername) {
-      basicAuth = `${encodeURIComponent(rc.githubUsername)}:${encodeURIComponent(rc.githubToken)}@`
+    if (rc.githubToken) {
+      if (rc.githubUsername) {
+        basicAuth = `${encodeURIComponent(rc.githubUsername)}:${encodeURIComponent(rc.githubToken)}@`
+      } else {
+        tokenQueryString = `?token=${encodeURIComponent(rc.githubToken)}`;
+      }
     }
 
-    let location = `https://${basicAuth}raw.githubusercontent.com/${org}/${repo}/${sha}/${path}`
-
-    if (rc.githubToken && !rc.githubUsername) {
-      location += `?token=${encodeURIComponent(rc.githubToken)}`;
-    }
+    let location = `https://${basicAuth}raw.githubusercontent.com/${org}/${repo}/${sha}/${path}${tokenQueryString}`
 
     return {
       raw,

--- a/src/utils/rc.ts
+++ b/src/utils/rc.ts
@@ -12,6 +12,7 @@ export interface RcConfig {
   key?: string
   cert?: string
   userAgent?: string
+  githubUsername?: string
   githubToken?: string
   registryURL?: string
   defaultSource?: string


### PR DESCRIPTION
Added a new setting in rc for githubUsername. If it is not specified, current functionality will stay the same for backwards compatibility. If it is set, then we use the github url of the form:
`http://<username>:<token>@raw.githubusercontent.com/path/to/file`

@blakeembrey 