### PR TITLE
Add a utility for pulling dependency information from path

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -4,6 +4,10 @@ export const CONFIG_FILE = `${PROJECT_NAME}.json`
 export const TYPINGS_DIR = PROJECT_NAME
 export const DTS_MAIN_FILE = 'main.d.ts'
 export const DTS_BROWSER_FILE = 'browser.d.ts'
+export const MAIN_TYPINGS_DIR = 'main'
+export const BROWSER_TYPINGS_DIR = 'browser'
+export const DEFINITIONS_DIR = 'definitions'
+export const AMBIENT_DEFINITIONS_DIR = 'ambient'
 
 export const HOMEPAGE = 'https://github.com/typings/typings'
 export const ISSUES_HOMEPAGE = 'https://github.com/typings/typings/issues'

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,12 +1,20 @@
 import { resolve, dirname, relative, extname, join } from 'path'
 import { resolve as resolveUrl, parse as parseUrl, format as formatUrl } from 'url'
-import { TYPINGS_DIR, DTS_MAIN_FILE, DTS_BROWSER_FILE } from './config'
+import {
+  TYPINGS_DIR,
+  DTS_MAIN_FILE,
+  DTS_BROWSER_FILE,
+  MAIN_TYPINGS_DIR,
+  BROWSER_TYPINGS_DIR,
+  DEFINITIONS_DIR,
+  AMBIENT_DEFINITIONS_DIR
+} from './config'
 import isAbsolute = require('is-absolute')
 
-const mainTypingsDir = join(TYPINGS_DIR, 'main/definitions')
-const browserTypingsDir = join(TYPINGS_DIR, 'browser/definitions')
-const ambientMainTypingsDir = join(TYPINGS_DIR, 'main/ambient')
-const ambientBrowserTypingsDir = join(TYPINGS_DIR, 'browser/ambient')
+const mainTypingsDir = join(TYPINGS_DIR, MAIN_TYPINGS_DIR, DEFINITIONS_DIR)
+const browserTypingsDir = join(TYPINGS_DIR, BROWSER_TYPINGS_DIR, DEFINITIONS_DIR)
+const ambientMainTypingsDir = join(TYPINGS_DIR, MAIN_TYPINGS_DIR, AMBIENT_DEFINITIONS_DIR)
+const ambientBrowserTypingsDir = join(TYPINGS_DIR, BROWSER_TYPINGS_DIR, AMBIENT_DEFINITIONS_DIR)
 
 /**
  * Consistent EOL behaviour.

--- a/src/utils/references.spec.ts
+++ b/src/utils/references.spec.ts
@@ -39,22 +39,23 @@ test('references', t => {
 
   t.test('parse dependency information from a reference path', t => {
     let path = '/some/path/to/typings/main/definitions/dep/index.d.ts'
-    let dependencyInfo = parseReferencePath(path)
+    let dependencyInfo = references.parseReferencePath(path)
 
-    t.equal(dependencyInfo.target, 'main')
-    t.equal(dependencyInfo.type, 'definitions')
+    t.equal(dependencyInfo.target, references.DependencyTarget.Main)
+    t.equal(dependencyInfo.type, references.DependencyType.External)
     t.equal(dependencyInfo.name, 'dep')
 
     path = '/some/other/path/to/typings/browser/ambient/otherDep/index.d.ts'
-    dependencyInfo = parseReferencePath(path)
+    dependencyInfo = references.parseReferencePath(path)
 
-    t.equal(dependencyInfo.target, 'browser')
-    t.equal(dependencyInfo.type, 'ambient')
+    t.equal(dependencyInfo.target, references.DependencyTarget.Browser)
+    t.equal(dependencyInfo.type, references.DependencyType.Ambient)
     t.equal(dependencyInfo.name, 'otherDep')
 
     path = '/path/to/typings/notMain/notAmbient/random/index.d.ts'
-    dependencyInfo = parseReferencePath(path)
+    dependencyInfo = references.parseReferencePath(path)
 
     t.equal(dependencyInfo, null)
+    t.end()
   })
 })

--- a/src/utils/references.spec.ts
+++ b/src/utils/references.spec.ts
@@ -36,4 +36,25 @@ test('references', t => {
     t.equal(actual, expected)
     t.end()
   })
+
+  t.test('parse dependency information from a reference path', t => {
+    let path = '/some/path/to/typings/main/definitions/dep/index.d.ts'
+    let dependencyInfo = parseReferencePath(path)
+
+    t.equal(dependencyInfo.target, 'main')
+    t.equal(dependencyInfo.type, 'definitions')
+    t.equal(dependencyInfo.name, 'dep')
+
+    path = '/some/other/path/to/typings/browser/ambient/otherDep/index.d.ts'
+    dependencyInfo = parseReferencePath(path)
+
+    t.equal(dependencyInfo.target, 'browser')
+    t.equal(dependencyInfo.type, 'ambient')
+    t.equal(dependencyInfo.name, 'otherDep')
+
+    path = '/path/to/typings/notMain/notAmbient/random/index.d.ts'
+    dependencyInfo = parseReferencePath(path)
+
+    t.equal(dependencyInfo, null)
+  })
 })


### PR DESCRIPTION
The prune feature will need to be able process reference paths in the *.d.ts files to determine if they match the typings.json file. 

This will requires the ability to parse dependency information from out of a reference path.