### PR TITLE
Only run pull build on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ notifications:
 before_install:
   - npm run bootstrap
 
+branches:
+  only:
+    - master
+
 node_js:
   - "0.10"
   - "0.12"


### PR DESCRIPTION
Tested this on `generator-typings`.
The PR will still build, as well as building master after it is merged.

With this, the build time for PR can cut in half.