### PR TITLE
Add name to typings.json

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,5 @@
 {
+  "name": "typings-core",
   "dependencies": {
     "any-promise": "github:typings/typed-any-promise#74ba6cf22149ff4de39c2338a9cb84f9ded6f042",
     "archy": "github:typings/typed-archy#3706c5e4df4efcc8cec8849a1c493cebd0830bea",


### PR DESCRIPTION
When installing typings for this module, I got the following warning:
````bash
typings INFO ambientdependencies "undefined" lists ambient dependencies on "node" and should be installed
````
Adding the `name` property to `typings.json` should help to properly display that this module is responsible for this warning.
