### PR TITLE
Pass `name` down compile dependency tree

### DIFF
--- a/src/interfaces/emitter.ts
+++ b/src/interfaces/emitter.ts
@@ -17,7 +17,6 @@ export interface Emitter extends EventEmitter {
   on (event: 'postmessage', listener: (e: PostMessageEvent) => any): this
   on (event: 'ambientdependencies', listener: (e: AmbientDependenciesEvent) => any): this
   on (event: 'badlocation', listener: (e: BadLocationEvent) => any): this
-  on (event: 'deprecated', listener: (e: DeprecatedEvent) => any): this
   on (event: string, listener: Function): this
 
   emit (event: 'reference', e: ReferenceEvent): boolean
@@ -30,7 +29,6 @@ export interface Emitter extends EventEmitter {
   emit (event: 'postmessage', e: PostMessageEvent): boolean
   emit (event: 'ambientdependencies', e: AmbientDependenciesEvent): boolean
   emit (event: 'badlocation', e: BadLocationEvent): boolean
-  emit (event: 'deprecated', e: DeprecatedEvent): boolean
   emit (event: string, ...args: any[]): boolean
 }
 
@@ -51,7 +49,8 @@ export interface ReferenceEvent {
 export interface ResolveEvent {
   src: string
   raw: string
-  parent?: DependencyTree
+  name: string
+  parent: DependencyTree
 }
 
 /**
@@ -119,13 +118,4 @@ export interface BadLocationEvent {
   type: string
   raw: string
   location: string
-}
-
-/**
- * Emit a deprecation warning.
- */
-export interface DeprecatedEvent {
-  raw: string
-  date: Date
-  parent: DependencyTree
 }

--- a/src/lib/compile.ts
+++ b/src/lib/compile.ts
@@ -284,12 +284,12 @@ function stringifyDependencyPath (path: string, options: StringifyOptions): Prom
   const importedPath = importPath(path, pathFromDefinition(path), options)
 
   // Return `null` to skip the dependency writing, could have the same import twice.
-  if (has(options.imported, importedPath)) {
+  if (has(imported, importedPath)) {
     return Promise.resolve<string>(null)
   }
 
   // Set the file to "already imported" to avoid duplication.
-  options.imported[importedPath] = true
+  imported[importedPath] = true
 
   // Emit compile events for progression.
   emitter.emit('compile', { name, path, tree, browser })


### PR DESCRIPTION
Related to https://github.com/typings/core/pull/87. Also kills the `deprecated` event.