### PR TITLE
Resolution

### DIFF
--- a/src/__test__/bundle-ambient/typings.json
+++ b/src/__test__/bundle-ambient/typings.json
@@ -1,4 +1,5 @@
 {
   "main": "index.d.ts",
-  "ambient": true
+  "ambient": true,
+	"resolution": "both"
 }

--- a/src/__test__/bundle/typings.json
+++ b/src/__test__/bundle/typings.json
@@ -2,5 +2,6 @@
   "main": "index.d.ts",
   "dependencies": {
     "test": "file:custom_typings/test.d.ts"
-  }
+  },
+	"resolution": "both"
 }

--- a/src/__test__/install-empty/typings.json
+++ b/src/__test__/install-empty/typings.json
@@ -1,1 +1,3 @@
-{}
+{
+	"resolution": "both"
+}

--- a/src/__test__/install-fixture/typings.json
+++ b/src/__test__/install-fixture/typings.json
@@ -4,5 +4,6 @@
   },
   "ambientDevDependencies": {
     "test": "file:custom_typings/ambient.d.ts"
-  }
+  },
+	"resolution": "both"
 }

--- a/src/__test__/prune-extraneous/typings.json
+++ b/src/__test__/prune-extraneous/typings.json
@@ -4,5 +4,6 @@
   },
   "ambientDevDependencies": {
     "test": "file:custom_typings/ambient.d.ts"
-  }
+  },
+	"resolution": "both"
 }

--- a/src/__test__/prune-production/typings.json
+++ b/src/__test__/prune-production/typings.json
@@ -4,5 +4,6 @@
   },
   "ambientDevDependencies": {
     "test": "file:custom_typings/ambient.d.ts"
-  }
+  },
+	"resolution": "both"
 }

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events'
 import { resolveAllDependencies } from './lib/dependencies'
 import compile, { CompileResult } from './lib/compile'
 import { writeFile, mkdirp, readConfig } from './utils/fs'
-import { findConfigFile } from './utils/find';
+import { findConfigFile } from './utils/find'
 import { Emitter } from './interfaces'
 import { InstallResult } from './install'
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -238,10 +238,10 @@ function writeBundle (results: CompileResult[], options: { cwd: string, resoluti
           }
 
           if (deresolution) {
-	          return Promise.all([
-		          rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
-		          unlink((<any>bundle)[deresolution])
-	          ])
+            return Promise.all([
+              rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
+              unlink((<any>bundle)[deresolution])
+            ])
           }
         })
     })

--- a/src/install.ts
+++ b/src/install.ts
@@ -22,7 +22,6 @@ export interface InstallDependencyOptions {
   ambient?: boolean
   cwd: string
   emitter?: Emitter
-	resolution?: string
 }
 
 /**
@@ -32,7 +31,6 @@ export interface InstallOptions {
   cwd: string
   production?: boolean
   emitter?: Emitter
-	resolution?: string
 }
 
 /**

--- a/src/install.ts
+++ b/src/install.ts
@@ -212,36 +212,37 @@ function writeBundle (results: CompileResult[], options: { cwd: string, resoluti
 
   return mkdirp(bundle.typings)
     .then(() => {
-	    return Promise.all(
-		    locations.length === 0
-		      ? [
-			        touch(bundle.main),
-			        touch(bundle.browser)
-		        ]
-			    : [
-			        transformDtsFile(bundle.main, x => x.concat(locations.map(x => x.main))),
-			        transformDtsFile(bundle.browser, x => x.concat(locations.map(x => x.browser)))
-		        ]
-		    )
-		    .then(() => findConfigFile(options.cwd))
-		    .then(path => readConfig(path))
-	      .then(config => {
-		      const {resolution} = config
-		      let deresolution: string
+      return Promise.all(
+        locations.length === 0
+          ? [
+              touch(bundle.main),
+              touch(bundle.browser)
+            ]
+          : [
+              transformDtsFile(bundle.main, x => x.concat(locations.map(x => x.main))),
+              transformDtsFile(bundle.browser, x => x.concat(locations.map(x => x.browser)))
+            ]
+        )
+        .then(() => findConfigFile(options.cwd))
+        .then(path => readConfig(path))
+        .then(config => {
+          const {resolution} = config
+          let deresolution: string
 
-		      // resolution default is 'main' only,
-		      // but can specify 'main', 'browser', or 'both' (or more precisely anything other than 'main' or 'browser')
-		      if(!resolution || resolution === 'main')
-			      deresolution = 'browser'
-		      else if(resolution && resolution === 'browser')
-			      deresolution = 'main'
+          // Resolution default is 'main' only,
+          // But can specify 'main', 'browser', or 'both' (or more precisely anything other than 'main' or 'browser')
+          if (!resolution || resolution === 'main') {
+            deresolution = 'browser'
+          } else if (resolution && resolution === 'browser') {
+            deresolution = 'main'
+          }
 
-		      if(deresolution)
-			      return Promise.all([
-				      rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
-				      unlink((<any>bundle)[deresolution])
-			      ])
-	      })
+          if(deresolution)
+            return Promise.all([
+              rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
+              unlink((<any>bundle)[deresolution])
+            ])
+        })
     })
 }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -4,8 +4,8 @@ import { dirname, join } from 'path'
 import { EventEmitter } from 'events'
 import { resolveDependency, resolveTypeDependencies } from './lib/dependencies'
 import compile, { CompileResult } from './lib/compile'
-import { findProject, findUp } from './utils/find'
-import { transformConfig, mkdirp, touch, transformDtsFile, readJson, mkdirpAndWriteFile } from './utils/fs'
+import { findProject, findUp, findConfigFile } from './utils/find'
+import { transformConfig, mkdirp, touch, transformDtsFile, readJson, mkdirpAndWriteFile, rimraf, unlink, readConfig } from './utils/fs'
 import { getTypingsLocation, getDependencyLocation, resolveFrom } from './utils/path'
 import { parseDependency, parseDependencyExpression, buildDependencyExpression } from './utils/parse'
 import { DependencyTree, Dependency, DependencyBranch, Emitter } from './interfaces'
@@ -22,6 +22,7 @@ export interface InstallDependencyOptions {
   ambient?: boolean
   cwd: string
   emitter?: Emitter
+	resolution?: string
 }
 
 /**
@@ -31,6 +32,7 @@ export interface InstallOptions {
   cwd: string
   production?: boolean
   emitter?: Emitter
+	resolution?: string
 }
 
 /**
@@ -206,24 +208,42 @@ function writeToConfig (results: CompileResult[], options: InstallDependencyOpti
 /**
  * Write a dependency to the filesytem.
  */
-function writeBundle (results: CompileResult[], options: { cwd: string }): Promise<any> {
+function writeBundle (results: CompileResult[], options: { cwd: string, resolution?: string }): Promise<any> {
   const bundle = getTypingsLocation(options)
   const locations = results.map(x => getDependencyLocation(x))
 
   return mkdirp(bundle.typings)
     .then(() => {
-      // Touch typings when no locations are installed.
-      if (locations.length === 0) {
-        return Promise.all([
-          touch(bundle.main),
-          touch(bundle.browser)
-        ])
-      }
+	    return Promise.all(
+		    locations.length === 0
+		      ? [
+			        touch(bundle.main),
+			        touch(bundle.browser)
+		        ]
+			    : [
+			        transformDtsFile(bundle.main, x => x.concat(locations.map(x => x.main))),
+			        transformDtsFile(bundle.browser, x => x.concat(locations.map(x => x.browser)))
+		        ]
+		    )
+		    .then(() => findConfigFile(options.cwd))
+		    .then(path => readConfig(path))
+	      .then(config => {
+		      const {resolution} = config
+		      let deresolution: string
 
-      return Promise.all([
-        transformDtsFile(bundle.main, x => x.concat(locations.map(x => x.main))),
-        transformDtsFile(bundle.browser, x => x.concat(locations.map(x => x.browser)))
-      ])
+		      // resolution default is 'main' only,
+		      // but can specify 'main', 'browser', or 'both' (or more precisely anything other than 'main' or 'browser')
+		      if(!resolution || resolution === 'main')
+			      deresolution = 'browser'
+		      else if(resolution && resolution === 'browser')
+			      deresolution = 'main'
+
+		      if(deresolution)
+			      return Promise.all([
+				      rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
+				      unlink((<any>bundle)[deresolution])
+			      ])
+	      })
     })
 }
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -237,11 +237,12 @@ function writeBundle (results: CompileResult[], options: { cwd: string, resoluti
             deresolution = 'main'
           }
 
-          if(deresolution)
-            return Promise.all([
-              rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
-              unlink((<any>bundle)[deresolution])
-            ])
+          if (deresolution) {
+	          return Promise.all([
+		          rimraf(join(dirname((<any>bundle)[deresolution]), deresolution)),
+		          unlink((<any>bundle)[deresolution])
+	          ])
+          }
         })
     })
 }

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -54,9 +54,9 @@ export interface ConfigJson {
   ambientDevDependencies?: Dependencies
 	/**
 	 * One of 'main', 'browser', or 'both'; if missing default is 'main'.
-	 * Specify what resolution algorithm(s) output should support 
+	 * Specify what resolution algorithm(s) output should support
 	 */
-	resolution?: string
+  resolution?: string
 }
 
 /**

--- a/src/interfaces/config.ts
+++ b/src/interfaces/config.ts
@@ -52,6 +52,11 @@ export interface ConfigJson {
    * A map of global dependencies required by the project during development.
    */
   ambientDevDependencies?: Dependencies
+	/**
+	 * One of 'main', 'browser', or 'both'; if missing default is 'main'.
+	 * Specify what resolution algorithm(s) output should support 
+	 */
+	resolution?: string
 }
 
 /**

--- a/src/prune.ts
+++ b/src/prune.ts
@@ -41,10 +41,17 @@ function transformBundles (config: ConfigJson, options: PruneOptions) {
   const dependencies = extend(config.dependencies, config.peerDependencies, production ? {} : config.devDependencies)
   const ambientDependencies = extend(config.ambientDependencies, production ? {} : config.ambientDevDependencies)
 
-  return Promise.all([
-    transformBundle(bundle.main, dependencies, ambientDependencies, options),
-    transformBundle(bundle.browser, dependencies, ambientDependencies, options)
-  ]).then(() => undefined)
+  const {resolution} = config
+  let transform: Promise<any>[] = []
+
+  if (!resolution || resolution === 'main' || resolution === 'both') {
+    transform.push(transformBundle(bundle.main, dependencies, ambientDependencies, options))
+  }
+  if (resolution && (resolution === 'browser' || resolution === 'both')) {
+    transform.push(transformBundle(bundle.browser, dependencies, ambientDependencies, options))
+  }
+
+  return Promise.all(transform).then(() => undefined)
 }
 
 /**


### PR DESCRIPTION
Implements a "resolution" option in typings.json.
Valid values are 'main', 'browser', 'both.
If "resolution" missing, defaults to 'main'.
'main' ensures only main.d.ts and main folder exist.
'browser' ensure only browse.d.ts and browser folder exist.
'both' ensures both exist.

For those with an isomorphic application, I would recommend each side having there own typings.json file adjacent to tsconfig.json, with the client side having "resolution" set to 'browser' as needed. You will not be required to alter either tsconfig.json in order for the compiler to use the correct typings (although you still can of you're really into tsconfig.json's "include" option).

This PR changes the default behavior so that the 99% use case is no longer the exception but the rule; i.e. only a single main.d.ts and main folder are generated, and tsc can be executed with minimal tsconfig.json. For a monolithic isomorphic application where a single typings.json is desired, "resolution" must now be set to 'both'.
