### PR TITLE
Kill `defaultAmbientSource` feature

### DIFF
--- a/src/interfaces/rc.ts
+++ b/src/interfaces/rc.ts
@@ -50,8 +50,4 @@ export interface RcConfig {
    * Override the default installation source (E.g. when doing `typings install debug`) (default: `npm`).
    */
   defaultSource?: string
-  /**
-   * Override the default ambient installation source (E.g. when doing `typings install node -A`) (default: `dt`).
-   */
-  defaultAmbientSource?: string
 }

--- a/src/utils/parse.spec.ts
+++ b/src/utils/parse.spec.ts
@@ -332,14 +332,6 @@ test('parse', t => {
       t.end()
     })
 
-    t.test('expand registry with default ambient source', t => {
-      const actual = expandRegistry('node', { ambient: true })
-      const expected = 'registry:dt/node'
-
-      t.deepEqual(actual, expected)
-      t.end()
-    })
-
     t.test('unknown scheme', t => {
       t.throws(() => parseDependency('random:fake/dep'), /Unknown dependency: /)
       t.end()

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -271,7 +271,7 @@ export function expandRegistry (raw: string, options: { ambient?: boolean }) {
   }
 
   const indexOf = raw.indexOf('~')
-  let source = options.ambient ? rc.defaultAmbientSource : rc.defaultSource
+  let source = rc.defaultSource
   let name: string
 
   if (indexOf === -1) {

--- a/src/utils/rc.ts
+++ b/src/utils/rc.ts
@@ -6,8 +6,7 @@ import { RcConfig } from '../interfaces'
 export const DEFAULTS = {
   userAgent: `${PROJECT_NAME}/{typingsVersion} node/{nodeVersion} {platform} {arch}`,
   registryURL: REGISTRY_URL,
-  defaultSource: 'npm',
-  defaultAmbientSource: 'dt'
+  defaultSource: 'npm'
 }
 
 export default extend(DEFAULTS, rc(PROJECT_NAME)) as RcConfig


### PR DESCRIPTION
Seems to be a source of confusion and a reason people never learn how it works, hence more logged issues.

Closes https://github.com/typings/typings/issues/321.