### PR TITLE
Get typings name for github: and files:

### DIFF
--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -464,7 +464,7 @@ function resolveTypeDependencyFrom (src: string, raw: string, options: Options) 
         // Emit "expected" global modules when installing top-level.
         if (parent == null && config.globalDependencies) {
           options.emitter.emit('globaldependencies', {
-            tree.name,
+            name: tree.name,
             raw,
             dependencies: config.globalDependencies
           })

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -464,7 +464,7 @@ function resolveTypeDependencyFrom (src: string, raw: string, options: Options) 
         // Emit "expected" global modules when installing top-level.
         if (parent == null && config.globalDependencies) {
           options.emitter.emit('globaldependencies', {
-            name,
+            tree.name,
             raw,
             dependencies: config.globalDependencies
           })

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -271,7 +271,7 @@ function resolveBowerDependencyFrom (
         const devDependencyMap = extend(options.dev ? bowerJson.devDependencies : {})
         const dependencyOptions = extend(options, { parent: tree })
 
-        options.emitter.emit('resolved', { name, src, tree, raw, parent })
+        options.emitter.emit('resolved', { name: name || tree.name, src, tree, raw, parent })
 
         return Promise.all([
           resolveBowerDependencyMap(componentPath, dependencyMap, dependencyOptions),
@@ -371,7 +371,7 @@ function resolveNpmDependencyFrom (src: string, raw: string, options: Options): 
         const peerDependencyMap = extend(options.peer ? packageJson.peerDependencies : {})
         const dependencyOptions = extend(options, { parent: tree })
 
-        options.emitter.emit('resolved', { name, src, tree, raw, parent })
+        options.emitter.emit('resolved', { name: name || tree.name, src, tree, raw, parent })
 
         return Promise.all([
           resolveNpmDependencyMap(src, dependencyMap, dependencyOptions),
@@ -437,7 +437,7 @@ function resolveTypeDependencyFrom (src: string, raw: string, options: Options) 
     .then<DependencyTree>(
       function (config) {
         const tree = extend(DEFAULT_DEPENDENCY, {
-          name: config.name || name,
+          name: config.name,
           main: config.main,
           version: config.version,
           browser: config.browser,
@@ -459,12 +459,12 @@ function resolveTypeDependencyFrom (src: string, raw: string, options: Options) 
         const globalDevDependencyMap = extend(global && dev ? config.globalDevDependencies : {})
         const dependencyOptions = extend(options, { parent: tree })
 
-        options.emitter.emit('resolved', { name, src, tree, raw, parent })
+        options.emitter.emit('resolved', { name: name || tree.name, src, tree, raw, parent })
 
         // Emit "expected" global modules when installing top-level.
         if (parent == null && config.globalDependencies) {
           options.emitter.emit('globaldependencies', {
-            name: tree.name,
+            name: name || tree.name,
             raw,
             dependencies: config.globalDependencies
           })

--- a/src/lib/dependencies.ts
+++ b/src/lib/dependencies.ts
@@ -437,7 +437,7 @@ function resolveTypeDependencyFrom (src: string, raw: string, options: Options) 
     .then<DependencyTree>(
       function (config) {
         const tree = extend(DEFAULT_DEPENDENCY, {
-          name: config.name,
+          name: config.name || name,
           main: config.main,
           version: config.version,
           browser: config.browser,


### PR DESCRIPTION
Alternatively can use `name: config.name || name`
Also, does it make sense to move
https://github.com/typings/core/blob/master/src/lib/dependencies.ts#L434
inside the promise to get the `config.name` emitted?

Closes https://github.com/typings/core/issues/115.