### PR TITLE
Added configurable URL rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "popsicle": "^8.0.2",
     "popsicle-proxy-agent": "^3.0.0",
     "popsicle-retry": "^3.2.0",
+    "popsicle-rewrite": "^1.0.0",
     "popsicle-status": "^2.0.0",
     "promise-finally": "^2.0.1",
     "rc": "^1.1.5",

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -74,9 +74,11 @@ test('install', t => {
         updated: '2016-02-26T13:23:28.000Z'
       })
 
-    nock('http://raw.githubusercontent.com/')
+    nock('https://raw.githubuserstuff.com/')
       .get('/DefinitelyTyped/DefinitelyTyped/48c1e3c1d6baefa4f1a126f188c27c4fefd36bff/node/node.d.ts')
       .reply(200, '// Type definitions for Node.js v4.x')
+
+    rc.urlRewrites = { "(.*)content(.*)": "$1stuff$2" }
 
     return writeFile(CONFIG, '{}')
       .then(function () {

--- a/src/install.spec.ts
+++ b/src/install.spec.ts
@@ -78,7 +78,7 @@ test('install', t => {
       .get('/DefinitelyTyped/DefinitelyTyped/48c1e3c1d6baefa4f1a126f188c27c4fefd36bff/node/node.d.ts')
       .reply(200, '// Type definitions for Node.js v4.x')
 
-    rc.urlRewrites = { "(.*)content(.*)": "$1stuff$2" }
+    rc.urlRewrites = { '(.*)content(.*)': '$1stuff$2' }
 
     return writeFile(CONFIG, '{}')
       .then(function () {

--- a/src/interfaces/rc.ts
+++ b/src/interfaces/rc.ts
@@ -50,4 +50,8 @@ export interface RcConfig {
    * Override the default installation source (E.g. when doing `typings install debug`) (default: `npm`).
    */
   defaultSource?: string
+  /**
+   * Defines URL rewrites. May be useful when using corporate registries.
+   */
+  urlRewrites?: { [pattern: string]: string }
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -7,6 +7,7 @@ import parse = require('parse-json')
 import popsicle = require('popsicle')
 import popsicleStatus = require('popsicle-status')
 import popsicleRetry = require('popsicle-retry')
+import popsicleRewrite = require('popsicle-rewrite')
 import detectIndent = require('detect-indent')
 import sortKeys = require('sort-keys')
 import Mkdirp = require('mkdirp')
@@ -160,6 +161,8 @@ export const readHttp = throat(5, function readHttp (url: string): Promise<strin
   })
     // Check responses are "200 OK".
     .use(popsicleStatus(200))
+    // Enable URL rewrite
+    .use(popsicleRewrite(rc.urlRewrites || {}))
     // Enable tracking of repeat users on the registry.
     .use(function (request, next) {
       if (request.Url.host === registryURL.host) {


### PR DESCRIPTION
When working in corporate environments, there are constraints that are not simply solved by using a proxy. Often, use of private and controlled registries is enforced and it is forbidden to pull artifacts directly from the internet.  
This PR proposes a general way to solve this by enabling url-rewriting at the http access level (popsicle). This, not only the official sources (typings, npm, github, ...) can be re-routed to a private server but also any other download required by a dependency.