### PR TITLE
Fix duplicate dependency loaded by different paths

### DIFF
--- a/src/lib/__test__/fixtures/compile-dep-dupe/foo/x.d.ts
+++ b/src/lib/__test__/fixtures/compile-dep-dupe/foo/x.d.ts
@@ -1,1 +1,3 @@
-export const wow: boolean
+import * as bar from './index'
+
+export { bar }

--- a/src/lib/compile.spec.ts
+++ b/src/lib/compile.spec.ts
@@ -310,7 +310,9 @@ test('compile', t => {
         .then(out => {
           t.equal(out.results.main, [
             'declare module \'~test~foo/x\' {',
-            'export const wow: boolean',
+            'import * as bar from \'~test~foo/index\'',
+            '',
+            'export { bar }',
             '}',
             '',
             'declare module \'~test~foo/index\' {',
@@ -412,7 +414,7 @@ test('compile', t => {
 
       const emitter = new EventEmitter()
 
-      return compile(node, ['main'], { name: 'name', cwd: __dirname, global: true, meta: false, emitter })
+      return compile(node, ['main'], { name: 'node', cwd: __dirname, global: true, meta: false, emitter })
         .then(out => {
           t.equal(out.results.main, [
             'declare module \'fs\' {',


### PR DESCRIPTION
From https://github.com/types/npm-koa/issues/2. Caused when loading `typings.json -> main` which was `application.d.ts`, but there was also an internal recursive import to `application` (without `.d.ts`). In that case, I was returning the same dependency from the cache but not caching the resolve path. When the resolve path is not in the cache, we're assuming it's a global path, resulting in a direct print of the dependency (e.g. `declare module "http://..."`).